### PR TITLE
Only add received messages to state if they belong to the current room

### DIFF
--- a/client/src/Customer.js
+++ b/client/src/Customer.js
@@ -13,6 +13,7 @@ class Customer extends Component {
     this.state = {
       currentUser: null,
       currentRoom: null,
+      currentRoomId: null,
       newMessage: "",
       messages: [],
       isLoading: false,

--- a/client/src/Support.js
+++ b/client/src/Support.js
@@ -11,6 +11,7 @@ class Support extends Component {
     this.state = {
       currentUser: null,
       currentRoom: null,
+      currentRoomId: null,
       newMessage: "",
       messages: [],
       rooms: []

--- a/client/src/sharedMethods.js
+++ b/client/src/sharedMethods.js
@@ -24,16 +24,21 @@ function sendMessage(event) {
 
 function connectToRoom(id) {
   const { currentUser } = this.state;
-
+  this.setState({
+    currentRoomId: id
+  });
   return currentUser
     .subscribeToRoom({
       roomId: `${id}`,
       messageLimit: 100,
       hooks: {
         onMessage: message => {
-          this.setState({
-            messages: [...this.state.messages, message]
-          });
+          const {currentRoomId} = this.state
+          if (message.roomId === currentRoomId){
+            this.setState({
+              messages: [...this.state.messages, message]
+            });
+          }
         }
       }
     })


### PR DESCRIPTION
This change checks the current room on receiving a message. Without this check, the application displays messages received from other rooms in the current room dialog.